### PR TITLE
EX-3408: do not add about:cliqz in session history

### DIFF
--- a/subprojects/fresh-tab-frontend/app/index.html
+++ b/subprojects/fresh-tab-frontend/app/index.html
@@ -22,5 +22,29 @@
       <script src="assets/fresh-tab.js"></script>
 
       {{content-for "body-footer"}}
+
+      <script type="text/javascript">
+        function getParameterByName(name) {
+          name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+          var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+          results = regex.exec(document.location.search);
+          return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+        }
+
+        // https://github.com/cliqz-oss/browser-core/issues/4
+        if(getParameterByName('e10s') == 'true'){
+          $(document).on('click', 'a[href]:not([href="#"])', function(ev){
+            // we need to replace the url for normal navigation to avoid adding it
+            // to session history (back is broken on e10s)
+            if(!(ev.ctrlKey || ev.metaKey || ev.altKey || ev.shiftKey)){
+              ev.preventDefault();
+              window.postMessage(JSON.stringify({
+                message: 'replaceURL',
+                url: ev.currentTarget.href
+              }), '*');
+            }
+          });
+        }
+      </script>
   </body>
 </html>


### PR DESCRIPTION
Hi @past !

We tried to fix https://github.com/cliqz-oss/browser-core/issues/4 but we couldn't find any elegant way to do it. It seems that it happens when running Electrolysis mode.
In this PR we implemented a work around - it basically behaves like the default new tab page in Firefox. It tries to avoid having about:cliqz in the session history.

What do you think about this approach?

Best,
Lucian
