### PR TITLE
Telemetry-22: Properly record in-content searches in the German locale

### DIFF
--- a/specific/firefox/cliqz@cliqz.com/modules/FirefoxTelemetry.jsm
+++ b/specific/firefox/cliqz@cliqz.com/modules/FirefoxTelemetry.jsm
@@ -86,7 +86,10 @@ Browser.prototype = {
   onLocationChange(webProgress, request, uri, flags) {
     try {
       if (webProgress.isTopLevel && uri.host) {
-        let host = uri.host.replace(/^www./, "").replace(/^search./, "");
+        let host = uri.host.replace(/^www./, "")
+                           .replace(/^de./, "")
+                           .replace(/^search./, "")
+                           .replace(/.de$/, ".com");
         if (gEngines.has(host)) {
           let rv = Services.search.parseSubmissionURL(uri.spec);
           // HACK: try to not count result pages we generated and subpages.
@@ -115,7 +118,10 @@ Browser.prototype = {
           flags & Ci.nsIWebProgressListener.STATE_IS_NETWORK &&
           (request && (request instanceof Ci.nsIChannel || "URI" in request)) &&
           request.URI.path == "/") {
-        let host = request.URI.host.replace(/^www./, "").replace(/^search./, "");
+        let host = request.URI.host.replace(/^www./, "")
+                                   .replace(/^de./, "")
+                                   .replace(/^search./, "")
+                                   .replace(/.de$/, ".com");
         if (gEngines.has(host)) {
           reportTelemetryValue("userVisitedEngineHost",
                                { engine: gEngines.get(host) });
@@ -135,7 +141,7 @@ XPCOMUtils.defineLazyGetter(this, "gEngines", () => {
     if (engine) {
       try {
         let engineHost = Services.io.newURI(engine.searchForm, null, null).host;
-        engines.set(engineHost.replace(/^www./, "").replace(/^search./, ""),
+        engines.set(engineHost.replace(/^www./, "").replace(/^de./, "").replace(/^search./, ""),
                     engine);
       } catch (ex) {}
     }

--- a/specific/firefox/cliqz@cliqz.com/modules/FirefoxTelemetry.jsm
+++ b/specific/firefox/cliqz@cliqz.com/modules/FirefoxTelemetry.jsm
@@ -96,6 +96,7 @@ Browser.prototype = {
           // This is tricky and working until the engines keep same param names.
           if (rv.engine &&
               !["hspart=mozilla", // Yahoo tracking
+                "fr=moz35",       // Yahoo tracking
                 "&b=",            // Yahoo paging
                 "client=firefox", // Google tracking
                 "&start=",        // Google paging


### PR DESCRIPTION
@mak77 does this look OK to you? I verified that Yahoo is properly accounted for in both host and results buckets, and Google is counted properly in host only. Getting it counted in results as well would require a more substantial change as the search plugin that ships with the German locale has no locale-specific information. It all happens server-side in Google's servers.

This is also why I had to hardcode the "de" string, it's not the localized build that causes this, but the geolocation of the client.

@luciancor if you are using a localized build, can you verify that this works for you?