### PR TITLE
Freshtab: optional browser theme

### DIFF
--- a/modules/freshtab/sources/background.es
+++ b/modules/freshtab/sources/background.es
@@ -35,6 +35,7 @@ export default background({
   core: inject.module('core'),
   geolocation: inject.module('geolocation'),
   messageCenter: inject.module('message-center'),
+  theme: inject.module('theme'),
 
   /**
   * @method init
@@ -394,9 +395,23 @@ export default background({
         isBrowser: isCliqzBrowser,
         showNewBrandAlert: this.shouldShowNewBrandAlert,
         messages: this.messages,
+        browserTheme: {
+          enabled: prefs.get('freshtab.browserTheme.enabled', false),
+        },
         isHistoryEnabled: prefs.get('modules.history.enabled', false),
         componentsState: this.getComponentsState(),
       };
+    },
+
+    toggleBrowserTheme() {
+      const enabled = prefs.get('freshtab.browserTheme.enabled', false);
+      const shouldEnable = !enabled;
+      prefs.set('freshtab.browserTheme.enabled', shouldEnable);
+      if (shouldEnable) {
+        this.theme.action('addClass', 'cliqz-blue');
+      } else {
+        this.theme.action('removeClass', 'cliqz-blue');
+      }
     },
     /**
     * @method takeFullTour

--- a/modules/freshtab/sources/home/components/app.jsx
+++ b/modules/freshtab/sources/home/components/app.jsx
@@ -31,7 +31,8 @@ class App extends React.Component {
           search: {},
           news: {},
           background: {},
-        }
+        },
+        browserTheme: {},
       },
       dials: {
         history: [],
@@ -56,6 +57,7 @@ class App extends React.Component {
     this.undoRemoval = this.undoRemoval.bind(this);
     this.closeUndo = this.closeUndo.bind(this);
     this.toggleComponent = this.toggleComponent.bind(this);
+    this.toggleBrowserTheme = this.toggleBrowserTheme.bind(this);
   }
 
   componentDidMount() {
@@ -286,6 +288,13 @@ class App extends React.Component {
     });
   }
 
+  toggleBrowserTheme() {
+    cliqz.freshtab.toggleBrowserTheme();
+    const state = this.state;
+    state.config.browserTheme.enabled = !state.config.browserTheme.enabled;
+    this.setState(state);
+  }
+
   toggleComponent(component) {
     cliqz.freshtab.toggleComponent(component);
     const config = this.state.config;
@@ -382,8 +391,10 @@ class App extends React.Component {
             onBackgroundImageChanged={bg => this.onBackgroundImageChanged(bg)}
             onNewsSelectionChanged={country => this.onNewsSelectionChanged(country)}
             toggleComponent={this.toggleComponent}
+            toggleBrowserTheme={this.toggleBrowserTheme}
             isOpen={this.state.isSettingsOpen}
             componentsState={this.state.config.componentsState}
+            browserTheme={this.state.config.browserTheme}
             hasHistorySpeedDialsToRestore={this.state.hasHistorySpeedDialsToRestore}
             toggle={() => this.toggleSettings()}
             restoreHistorySpeedDials={() => this.restoreHistorySpeedDials()}

--- a/modules/freshtab/sources/home/components/settings.jsx
+++ b/modules/freshtab/sources/home/components/settings.jsx
@@ -60,6 +60,14 @@ export default class Settings extends React.Component {
           </div>
 
           <div className="settings-row">
+            <span className="label">Browser theme</span>
+            <Switch
+              isChecked={this.props.browserTheme.enabled}
+              toggleComponent={() => this.props.toggleBrowserTheme()}
+            />
+          </div>
+
+          <div className="settings-row">
             <span className="label">{t('app.settings.background.label')}</span>
             <ul className="background-selection-list">
               <li>
@@ -181,4 +189,8 @@ Settings.propTypes = {
   toggleComponent: PropTypes.func,
   restoreHistorySpeedDials: PropTypes.func,
   hasHistorySpeedDialsToRestore: PropTypes.bool,
+  toggleBrowserTheme: PropTypes.func,
+  browserTheme: PropTypes.shape({
+    enabled: PropTypes.bool,
+  }),
 };

--- a/modules/theme/sources/background.es
+++ b/modules/theme/sources/background.es
@@ -1,15 +1,25 @@
 import background from '../core/base/background';
+import inject from '../core/kord/inject';
+import { forEachWindow } from '../core/browser';
 
 export default background({
-  enabled() {
-    return true;
-  },
-
-
   init() {
   },
 
   unload() {
   },
 
+  actions: {
+    addClass(className) {
+      forEachWindow(window => {
+        inject.module('theme').windowAction(window, 'addClass', className);
+      });
+    },
+
+    removeClass(className) {
+      forEachWindow(window => {
+        inject.module('theme').windowAction(window, 'removeClass', className);
+      });
+    },
+  },
 });

--- a/modules/theme/sources/styles/_shared.scss
+++ b/modules/theme/sources/styles/_shared.scss
@@ -1,0 +1,5 @@
+#main-window.cliqz-blue {
+    #titlebar, #tab-view-deck, #titlebar-content, #tabbrowser-tabs {
+        background-color: #00ADEF;
+    }
+}

--- a/modules/theme/sources/styles/theme-linux.scss
+++ b/modules/theme/sources/styles/theme-linux.scss
@@ -1,3 +1,4 @@
+
 $urlbar-holder: 33px;
 $urlbar-elms-height: 32px;
 $buttons-hover-color: #e7e7e7;
@@ -237,7 +238,6 @@ window:not([chromehidden~="toolbar"]) #urlbar-wrapper {
 
 
 /*==== FF Color */
-
 #titlebar,
 #tab-view-deck,
 #titlebar-content,
@@ -666,3 +666,5 @@ toolbaritem[sdkstylewidget="true"] > toolbarbutton, [cui-areatype="menu-panel"]:
         list-style-image: var(--menupanel-list-style-image-2x);
     }
 }
+
+@import 'shared';

--- a/modules/theme/sources/window.es
+++ b/modules/theme/sources/window.es
@@ -1,4 +1,5 @@
 import utils from '../core/utils';
+import prefs from '../core/prefs';
 import { addStylesheet, removeStylesheet } from "../core/helpers/stylesheet";
 
 /**
@@ -14,6 +15,23 @@ export default class {
     this.window = settings.window;
     // check for using theme from extension or it exist in browser
     this.useTheme = !this.window.document.documentElement.getAttribute("cliqzBrowser");
+    this.actions = {
+      addClass: (className) => {
+        this.windowNode.classList.add(className);
+      },
+      removeClass: (className) => {
+        this.windowNode.classList.remove(className);
+      },
+    }
+
+    const theme = prefs.get('freshtab.browserTheme.enabled', false);
+    if (theme) {
+      this.actions.addClass('cliqz-blue');
+    }
+  }
+
+  get windowNode() {
+    return this.window.document.getElementById('main-window');
   }
 
   /**


### PR DESCRIPTION
design:
![cliqz tab alps 2x](https://user-images.githubusercontent.com/1228153/29331833-23e18fb6-81fe-11e7-894f-b6ddcbb07dfb.png)

TODO:
* freshtab i18n
* move prefs logic completely to theme module
* freshtab: show switch only in Cliqz browser
* polish up CSS @alexei-cliqz
* freshtab: add background image
