### PR TITLE
Support Implicit Grant and Authorization code OAuth flows detection

### DIFF
--- a/modules/antitracking/sources/steps/oauth-detector.es
+++ b/modules/antitracking/sources/steps/oauth-detector.es
@@ -127,7 +127,7 @@ export default class OAuthDetector {
   /**
    * Pipeline step to check if this request is part of a OAuth flow. This is done by
    * checking that the following three conditions are met:
-   *  - The third-party url path contains '/oauth'
+   *  - The third-party url path contains '/oauth' or '/authorize'
    *  - The user has recently clicked in the source tab (i.e. the site wanting to authenticate the
    * user)
    *  - The user has recently visited the oauth domain (the authentication provider)
@@ -135,7 +135,12 @@ export default class OAuthDetector {
    * @returns false if the request is an oauth request, true otherwise
    */
   checkIsOAuth(state) {
-    if (state.urlParts.path.indexOf('/oauth') > -1 &&
+    const oAuthUrls = ['/oauth', '/authorize'];
+    const mapper = (oAuthUrl) => state.urlParts.path.indexOf(oAuthUrl) > -1;
+    const reducer = (accumulator, currentValue) => accumulator || currentValue;
+    const isOAuthFlow = oAuthUrls.map(mapper).reduce(reducer);
+
+    if (isOAuthFlow &&
       this.clickActivity[state.tabId] && this.siteActivitiy[state.urlParts.hostname]) {
       const clickedPage = URLInfo.get(this.clickActivity[state.tabId]);
       if (clickedPage !== null && clickedPage.hostname === state.sourceUrlParts.hostname) {

--- a/modules/antitracking/sources/steps/oauth-detector.es
+++ b/modules/antitracking/sources/steps/oauth-detector.es
@@ -136,7 +136,7 @@ export default class OAuthDetector {
    */
   checkIsOAuth(state) {
     const oAuthUrls = ['/oauth', '/authorize'];
-    const mapper = (oAuthUrl) => state.urlParts.path.indexOf(oAuthUrl) > -1;
+    const mapper = oAuthUrl => state.urlParts.path.indexOf(oAuthUrl) > -1;
     const reducer = (accumulator, currentValue) => accumulator || currentValue;
     const isOAuthFlow = oAuthUrls.map(mapper).reduce(reducer);
 

--- a/modules/antitracking/tests/unit/oauth-detector-test.es
+++ b/modules/antitracking/tests/unit/oauth-detector-test.es
@@ -178,8 +178,13 @@ export default describeModule('antitracking/steps/oauth-detector',
           detectorInstance.unload();
         });
 
-        it('returns true when there has been no activity', () => {
+        it('returns true when there has been no activity and the URL contains "/oauth"', () => {
           const state = mockState(5, 'https://auth.ghostery.com/oauth', 'https://cliqz.com/');
+          chai.expect(detectorInstance.checkIsOAuth(state)).to.be.true;
+        });
+
+        it('returns true when there has been no activity and the URL contains "/authorize"', () => {
+          const state = mockState(5, 'https://auth.ghostery.com/authorize', 'https://cliqz.com/');
           chai.expect(detectorInstance.checkIsOAuth(state)).to.be.true;
         });
 


### PR DESCRIPTION
## Description

The `checkIsOAuth` function currently only checks OAuth Flows making a call to `/oauth*`. These are usually **Resource Owner Password Grant** and and **Client Credentials**.
However, most Single Page Applications today use flows such as the **Implicit Grant** or **Authorization Code Grant**, which perform calls to `/authorize` endpoints for the most part.

This PR ensures that these flows are supported for users of Auth0, one of the leading 3rd party solution for authentication & identity management. You can find more information about the endpoints they use (which are OAuth2.0 & OIDC Conformant) on the following link: https://auth0.com/docs/api/authentication#authorize-application

Here are a few extracts from the documentation:

> To begin an OAuth 2.0 Authorization flow, your application should first send the user to the authorization URL.
> The purpose of this call is to obtain consent from the user to invoke the API (specified in audience) and do certain things (specified in scope) on behalf of the user.
> The OAuth 2.0 flows that require user authorization are:
> 
> - [Authorization Code Grant](https://auth0.com/docs/api-auth/grant/authorization-code)
> - [Authorization Code Grant using Proof Key for Code Exchange (PKCE)](https://auth0.com/docs/api--auth/grant/authorization-code-pkce)
> - [Implicit Grant](https://auth0.com/docs/api-auth/grant/implicit)
> 
> On the other hand, the [Resource Owner Password Grant](https://auth0.com/docs/api-auth/grant/password) and [Client Credentials](https://auth0.com/docs/api-auth/grant/client-credentials) flows do not use this endpoint since there is no user authorization involved. Instead they invoke directly the POST /oauth/token endpoint to retrieve an Access Token.

> 
> [...]
> 
> ### Authorization Code Grant
> 
> `GET /authorize`
> This is the OAuth 2.0 grant that regular web apps utilize in order to access an API.
> 
> ### Authorization Code Grant (PKCE)
> 
> `GET /authorize`
> This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. Before starting with this flow, you need to generate and store a `code_verifier`, and using that, generate a `code_challenge` that will be sent in the authorization request.
> 
> 
> ### Implicit Grant
> 
> `GET /authorize`
> This is the OAuth 2.0 grant that web apps utilize in order to access an API.

## Problem it solves

This has caused us issues in production for about 1 month now, we've reached out Ghostery's support to find resolutions but it doesn't seem to be responsive or able to provide a long term solution (they only suggested to whitelist our `client_id` for Auth0, which is not a scalable and future proof solution).

Below you can find two example symptoms that are preventing Ghostery users from accessing our application:

![image](https://user-images.githubusercontent.com/11708669/40787144-2d1ddfe4-64ed-11e8-917a-338d713dd760.png)

![image](https://user-images.githubusercontent.com/11708669/40787184-456626ce-64ed-11e8-8f63-de705be199b3.png)

From what I understood of the code-base, this Pull Request should be enough to prevent the scrubber from being executed on these `/authorize` paths, and should fix this issue for Auth0 users using the same OAuth 2.0 flows.

## Testing

I was not able to setup a development/test environment. I tried on both Windows and Ubuntu, with `yarn` and `npm` and keep having errors with the installation of the packages. I am running Node v10 (which is above the v4 listed in the readme's requirement) and usually don't have any issues with JavaScript dev environments.

This means that I was not able to run the unit test I added. If you think you can help me setup an environment, I will be happy to run it and perform functional tests to make sure this fixes our issue.

PS: the style-guide mentioned in the README.md is 404: https://github.com/cliqz/js-style-guide

## Last note

This error is currently happening on our production environment. We would appreciate if we can validate and push this fix ASAP, as it prevents our Ghostery users from logging in to our application.